### PR TITLE
graph-struct-2: fixed problem with graph::Net templating

### DIFF
--- a/src/graph.hpp
+++ b/src/graph.hpp
@@ -2,42 +2,18 @@
 #define GRAPH_HPP
 
 #include <edge.hpp>
+#include <graph_traits.hpp>
 #include <impl/graph.hpp>
 #include <impl/meta_utils.hpp>
 
 namespace graph {
 
-class GraphTrait {
-protected:
-    GraphTrait() = default;
-};
-
-class EdgeTrait {
-protected:
-    EdgeTrait() = default;
-};
-
-// TODO: source and sink should be Node* type.
-// Should we inherit all nodes from base Node class
-// or should we apply more template woodoo?
-class Net : public GraphTrait {
-public:
-    Net(int source, int sink) : source(source), sink(sink) {}
-    int source, sink;
-};
-
-class Weighted : public EdgeTrait {
-public:
-    Weighted(uint32_t weight) : weight(weight) {}
-    uint32_t weight;
-};
-
 template<typename Node, typename... Traits>
     requires (graph_impl::Trait<Traits> && ...)
 using Graph = graph_impl::Graph<
     Node,
-    graph_impl::filter<graph_impl::graph_trait_condition, Traits...>,
-    graph_impl::filter<graph_impl::edge_trait_condition, Traits...>
+    graph_impl::build_graph_traits<Node, Traits...>,
+    graph_impl::build_edge_traits<Node, Traits...>
 >;
 
 }  // graph

--- a/src/graph_traits.hpp
+++ b/src/graph_traits.hpp
@@ -1,0 +1,29 @@
+#ifndef GRAPH_TRAITS_HPP
+#define GRAPH_TRAITS_HPP
+
+namespace graph {
+
+class GraphTrait {
+protected:
+    GraphTrait() = default;
+};
+
+class EdgeTrait {
+protected:
+    EdgeTrait() = default;
+};
+
+class Net : public GraphTrait {
+protected:
+    Net() = default;
+};
+
+class Weighted : public EdgeTrait {
+public:
+    Weighted(unsigned weight) : weight(weight) {}
+    const unsigned weight;
+};
+
+}  // graph
+
+#endif  // GRAPH_TRAITS_HPP

--- a/src/impl/graph.hpp
+++ b/src/impl/graph.hpp
@@ -30,9 +30,14 @@ class Graph<
     public GraphTraits... {
 public:
     Graph() = default;
-    Graph(std::initializer_list<Node> nodes,
+    Graph(std::initializer_list<Node> node_list,
           GraphTraits... graph_traits) :
-          nodes(std::move(nodes)), GraphTraits(std::move(graph_traits))... {};
+          nodes(std::move(node_list)), GraphTraits(std::move(graph_traits))... {
+        if (std::is_base_of<Net<Node>, typeof(*this)>::value) {
+            nodes.insert(static_cast<Net<Node>*>(this)->source);
+            nodes.insert(static_cast<Net<Node>*>(this)->sink);
+        }
+    }
 
     virtual void addEdge(const graph::Edge<Node, EdgeTraits...>& edge) {
         nodes.insert(edge.from);

--- a/src/impl/graph.hpp
+++ b/src/impl/graph.hpp
@@ -2,12 +2,21 @@
 #define IMPL_GRAPH_HPP
 
 #include <edge.hpp>
+#include <graph_traits.hpp>
 
 #include <map>
 #include <set>
 #include <utility>
 
 namespace graph_impl {
+
+template<typename Node>
+class Net : public graph::GraphTrait {
+public:
+    Net(Node source, Node sink) :
+        source(std::move(source)), sink(std::move(sink)) {}
+    Node source, sink;
+};
 
 template<typename Node, typename GraphTraitList, typename EdgeTraitList>
 class Graph;


### PR DESCRIPTION
Went template woodoo way with graph::Net trait

```C++
class Node {
public:
    Node(int a, int b) : a(a), b(b) {}
    int a, b;
};

int main() {
    graph::Graph<int, graph::Net, graph::Weighted> g{{1, 2, 3}, {1, 3} /* <-- Setting source and sink here */};
    graph::Edge<Node> e{ {1, 2}, {1, 2} };
    g.addEdge({1, 2, 1  /* <-- weight */});
    g.addEdge({2, 3, 2});
    g.addEdge({3, 1, 3});
    return 0;
}
```