### PR TITLE
graph-struct-5: introduced NoConstructorTrait feature

### DIFF
--- a/src/graph.hpp
+++ b/src/graph.hpp
@@ -13,7 +13,9 @@ template<typename Node, typename... Traits>
 using Graph = graph_impl::Graph<
     Node,
     graph_impl::build_graph_traits<Node, Traits...>,
-    graph_impl::build_edge_traits<Node, Traits...>
+    graph_impl::build_edge_traits<Node, Traits...>,
+    graph_impl::constructible_graph_traits<Node, Traits...>,
+    graph_impl::constructible_edge_traits<Node, Traits...>
 >;
 
 }  // graph

--- a/src/graph_traits.hpp
+++ b/src/graph_traits.hpp
@@ -13,13 +13,17 @@ protected:
     EdgeTrait() = default;
 };
 
+class NoConstructorTrait {
+protected:
+    NoConstructorTrait() = default;
+};
+
 class Net : public GraphTrait {
 protected:
     Net() = default;
 };
 
-// TODO: filter away such classes from Graph constructor args
-class Directed : public GraphTrait {
+class Directed : public GraphTrait, NoConstructorTrait {
 public:
     Directed() = default;
 };

--- a/src/impl/graph.hpp
+++ b/src/impl/graph.hpp
@@ -43,8 +43,8 @@ public:
     Graph(std::initializer_list<Node> node_list, ConstructibleGraphTraits... graph_traits) :
           nodes(std::move(node_list)), ConstructibleGraphTraits(std::move(graph_traits))... {
         if (std::is_base_of_v<Net<Node>, typeof(*this)>) {
-            nodes.insert(static_cast<Net<Node>*>(this)->source);
-            nodes.insert(static_cast<Net<Node>*>(this)->sink);
+            nodes.insert(reinterpret_cast<Net<Node>*>(this)->source);
+            nodes.insert(reinterpret_cast<Net<Node>*>(this)->sink);
         }
     }
 

--- a/src/impl/graph.hpp
+++ b/src/impl/graph.hpp
@@ -19,22 +19,29 @@ public:
     const Node source, sink;
 };
 
-template<typename Node, typename GraphTraitList, typename EdgeTraitList>
+template<typename Node, typename GraphTraitList, typename EdgeTraitList,
+    typename ConstructibleGraphTraitList, typename ConstructibleEdgeTraitList>
 class Graph;
 
 template<
     typename Node,
     template<typename...> typename GraphTraitList, typename... GraphTraits,
-    template<typename...> typename EdgeTraitList, typename... EdgeTraits>
+    template<typename...> typename EdgeTraitList, typename... EdgeTraits,
+    template<typename...> typename ConstructibleGraphTraitList,
+        typename... ConstructibleGraphTraits,
+    template<typename...> typename ConstructibleEdgeTraitList,
+        typename... ConstructibleEdgeTraits>
 class Graph<
-    Node, GraphTraitList<GraphTraits...>, EdgeTraitList<EdgeTraits...> > :
+    Node, GraphTraitList<GraphTraits...>, EdgeTraitList<EdgeTraits...>,
+    ConstructibleGraphTraitList<ConstructibleGraphTraits...>,
+    ConstructibleEdgeTraitList<ConstructibleEdgeTraits...> > :
     public GraphTraits... {
-    using Edge = graph::Edge<Node, EdgeTraits...>;
+    using Edge = graph::Edge<Node, ConstructibleEdgeTraits...>;
 
 public:
     Graph() = default;
-    Graph(std::initializer_list<Node> node_list, GraphTraits... graph_traits) :
-          nodes(std::move(node_list)), GraphTraits(std::move(graph_traits))... {
+    Graph(std::initializer_list<Node> node_list, ConstructibleGraphTraits... graph_traits) :
+          nodes(std::move(node_list)), ConstructibleGraphTraits(std::move(graph_traits))... {
         if (std::is_base_of_v<Net<Node>, typeof(*this)>) {
             nodes.insert(static_cast<Net<Node>*>(this)->source);
             nodes.insert(static_cast<Net<Node>*>(this)->sink);


### PR DESCRIPTION
Traits inherited from NoConstructorTrait are not expected in graph constructor.
For example:
```C++
class Directed : public GraphTrait, NoConstructorTrait {
public:
    Directed() = default;
};
```
then
```C++
graph::Graph<int, graph::Directed> directed_graph({1, 2, 3});
```
instead of
```C++
graph::Graph<int, graph::Directed> directed_graph({1, 2, 3}, {});
```