### PR TITLE
graph-struct-6: replaced `typeof` with new `graph_impl::contains_type`

### DIFF
--- a/src/impl/graph.hpp
+++ b/src/impl/graph.hpp
@@ -4,6 +4,7 @@
 #include <edge.hpp>
 #include <graph_traits.hpp>
 #include <impl/graph_traits.hpp>
+#include <impl/meta_utils.hpp>
 
 #include <map>
 #include <set>
@@ -37,7 +38,7 @@ public:
         ConstructibleGraphTraits... graph_traits) :
       nodes(std::move(node_list)),
       ConstructibleGraphTraits(std::move(graph_traits))... {
-    if (std::is_base_of_v<Net<Node>, typeof(*this)>) {
+    if (contains_type<Net<Node>, GraphTraits...>::value) {
       nodes.insert(reinterpret_cast<Net<Node>*>(this)->source);
       nodes.insert(reinterpret_cast<Net<Node>*>(this)->sink);
     }
@@ -48,7 +49,7 @@ public:
     nodes.insert(edge.to);
     edges[edge.from].insert(edge);
     edges[edge.to].insert(edge);
-    if (!std::is_base_of_v<graph::Directed, typeof(*this)>) {
+    if (!contains_type<graph::Directed, GraphTraits...>::value) {
       edges[edge.from].insert(graph::reversed(edge));
       edges[edge.to].insert(graph::reversed(edge));
     }

--- a/src/impl/meta_utils.hpp
+++ b/src/impl/meta_utils.hpp
@@ -104,7 +104,8 @@ template <
     template<typename...> typename List, typename SourceT, typename TargetT,
     typename... Tail>
 struct replace_all_impl<TraitList, List<SourceT, TargetT>, Tail...> {
-  using type = replace_all_impl<replace_t<SourceT, TargetT, TraitList>, Tail...>::type;
+  using type =
+      replace_all_impl<replace_t<SourceT, TargetT, TraitList>, Tail...>::type;
 };
 
 template<typename, typename>
@@ -115,6 +116,20 @@ template<
     template<typename...> typename ReplacementList, typename... Replacements>
 struct replace_all<TraitList, ReplacementList<Replacements...> > {
   using type = replace_all_impl<TraitList, Replacements...>::type;
+};
+
+template<typename, typename, typename...>
+struct contains_type_impl;
+
+template<typename Result,  typename T>
+struct contains_type_impl<Result, T> {
+  using value = Result;
+};
+
+template<typename Result,  typename T, typename Head, typename... Tail>
+struct contains_type_impl<Result,  T, Head, Tail...> {
+  using value = contains_type_impl<
+      std::disjunction<Result, std::is_same<T, Head> >, T, Tail...>::value;
 };
 
 template<typename Node, typename TraitList>
@@ -137,6 +152,9 @@ using constructible_trait_condition =
 }  // namespace
 
 namespace graph_impl {
+
+template<typename T, typename... Ts>
+using contains_type = contains_type_impl<std::false_type, T, Ts...>::value;
 
 template<typename Node, typename... Traits>
 using build_graph_traits =


### PR DESCRIPTION
```C++
contains_type<graph::Directed, GraphTraits...>::value
```
instead of
```C++
std::is_base_of_v<graph::Directed, typeof(*this)>
```