### PR TITLE
graph-struct-7: introduced Multigraph and HashTableBased traits

### DIFF
--- a/src/edge.hpp
+++ b/src/edge.hpp
@@ -1,6 +1,9 @@
 #ifndef EDGE_HPP
 #define EDGE_HPP
 
+#include <impl/graph_traits.hpp>
+
+#include <functional>
 #include <utility>
 
 namespace graph {
@@ -24,13 +27,35 @@ Edge<Node, Types...> reversed(const Edge<Node, Types...>& edge) {
 }
 
 template<typename Node, typename... Types>
-bool operator<(const Edge<Node, Types...>& lhe, 
-               const Edge<Node, Types...>& rhe) {
-  if (lhe.from != rhe.from)
+bool operator<(const Edge<Node, graph_impl::RBTreeBasedEdge, Types...>& lhe,
+               const Edge<Node, graph_impl::RBTreeBasedEdge, Types...>& rhe) {
+  if (lhe.from < rhe.from || rhe.from < lhe.from)
     return lhe.from < rhe.from;
   return lhe.to < rhe.to;
 }
 
+template<typename Node, typename... Types>
+bool operator==(
+      const Edge<Node, graph_impl::HashTableBasedEdge, Types...>& lhe,
+      const Edge<Node, graph_impl::HashTableBasedEdge, Types...>& rhe) {
+  return lhe.from == rhe.from && lhe.to == rhe.to;
+}
+
 }  // graph
+
+namespace std {
+
+template<typename Node, typename... Types>
+struct hash<graph::Edge<Node, graph_impl::HashTableBasedEdge, Types...> > {
+  std::size_t operator()(
+      const graph::Edge<Node, graph_impl::HashTableBasedEdge, Types...>& edge
+  ) const noexcept {
+    const std::size_t h1 = std::hash<Node>{}(edge.from);
+    const std::size_t h2 = std::hash<Node>{}(edge.to);
+    return h1 ^ (h2 << 1);
+  }
+};
+
+}  // std
 
 #endif  // EDGE_H

--- a/src/edge.hpp
+++ b/src/edge.hpp
@@ -28,17 +28,16 @@ Edge<Node, Types...> reversed(const Edge<Node, Types...>& edge) {
 }
 
 template<typename Node, typename... Types>
-bool operator<(const Edge<Node, graph_impl::RBTreeBasedEdge, Types...>& lhe,
-               const Edge<Node, graph_impl::RBTreeBasedEdge, Types...>& rhe) {
+bool operator<(const Edge<Node, Types...>& lhe,
+               const Edge<Node, Types...>& rhe) {
   if (lhe.from < rhe.from || rhe.from < lhe.from)
     return lhe.from < rhe.from;
   return lhe.to < rhe.to;
 }
 
 template<typename Node, typename... Types>
-bool operator==(
-      const Edge<Node, graph_impl::HashTableBasedEdge, Types...>& lhe,
-      const Edge<Node, graph_impl::HashTableBasedEdge, Types...>& rhe) {
+bool operator==(const Edge<Node, Types...>& lhe,
+                const Edge<Node, Types...>& rhe) {
   return lhe.from == rhe.from && lhe.to == rhe.to;
 }
 
@@ -47,10 +46,9 @@ bool operator==(
 namespace std {
 
 template<typename Node, typename... Types>
-struct hash<graph::Edge<Node, graph_impl::HashTableBasedEdge, Types...> > {
+struct hash<graph::Edge<Node, Types...> > {
   std::size_t operator()(
-      const graph::Edge<Node, graph_impl::HashTableBasedEdge, Types...>& edge
-  ) const noexcept {
+      const graph::Edge<Node, Types...>& edge) const noexcept {
     const std::size_t h1 = std::hash<Node>{}(edge.from);
     const std::size_t h2 = std::hash<Node>{}(edge.to);
     return h1 ^ (h2 << 1 | (h2 >> (CHAR_BIT * sizeof(h2) - 1)));

--- a/src/edge.hpp
+++ b/src/edge.hpp
@@ -1,8 +1,6 @@
 #ifndef EDGE_HPP
 #define EDGE_HPP
 
-#include <impl/graph_traits.hpp>
-
 #include <climits>
 #include <functional>
 #include <utility>

--- a/src/edge.hpp
+++ b/src/edge.hpp
@@ -3,6 +3,7 @@
 
 #include <impl/graph_traits.hpp>
 
+#include <climits>
 #include <functional>
 #include <utility>
 
@@ -52,7 +53,7 @@ struct hash<graph::Edge<Node, graph_impl::HashTableBasedEdge, Types...> > {
   ) const noexcept {
     const std::size_t h1 = std::hash<Node>{}(edge.from);
     const std::size_t h2 = std::hash<Node>{}(edge.to);
-    return h1 ^ (h2 << 1);
+    return h1 ^ (h2 << 1 | (h2 >> (CHAR_BIT * sizeof(h2) - 1)));
   }
 };
 

--- a/src/graph_traits.hpp
+++ b/src/graph_traits.hpp
@@ -24,8 +24,18 @@ protected:
 };
 
 class Directed : public GraphTrait, NoConstructorTrait {
-public:
+protected:
   Directed() = default;
+};
+
+class Multigraph : public GraphTrait, NoConstructorTrait {
+protected:
+  Multigraph() = default;
+};
+
+class HashTableBased : public GraphTrait, NoConstructorTrait {
+protected:
+  HashTableBased() = default;
 };
 
 class Weighted : public EdgeTrait {

--- a/src/impl/graph.hpp
+++ b/src/impl/graph.hpp
@@ -52,7 +52,7 @@ class Graph<
           std::set<ContainerEdge>
       >
   >;
-  using GraphMap = std::conditional_t<
+  using EdgeMap = std::conditional_t<
       contains_type_v<graph::HashTableBased, GraphTraits...>,
       std::unordered_map<Node, EdgeSet>,
       std::map<Node, EdgeSet>
@@ -116,7 +116,7 @@ public:
   }
 
 private:
-  GraphMap edges;
+  EdgeMap edges;
   NodeSet nodes;
 };
 

--- a/src/impl/graph.hpp
+++ b/src/impl/graph.hpp
@@ -37,7 +37,8 @@ class Graph<
   using ContainerEdge = std::conditional_t<
       contains_type_v<graph::HashTableBased, GraphTraits...>,
       graph::Edge<Node, graph_impl::HashTableBasedEdge, EdgeTraits...>,
-      graph::Edge<Node, graph_impl::RBTreeBasedEdge, EdgeTraits...> >;
+      graph::Edge<Node, graph_impl::RBTreeBasedEdge, EdgeTraits...>
+  >;
   using EdgeSet = std::conditional_t<
       contains_type_v<graph::HashTableBased, GraphTraits...>,
       std::conditional_t<

--- a/src/impl/graph.hpp
+++ b/src/impl/graph.hpp
@@ -75,7 +75,7 @@ public:
   }
 
   void addEdge(const Edge& edge) {
-    const ContainerEdge container_edge =
+    const ContainerEdge& container_edge =
         reinterpret_cast<const ContainerEdge&>(edge);
     nodes.insert(container_edge.from);
     nodes.insert(container_edge.to);

--- a/src/impl/graph.hpp
+++ b/src/impl/graph.hpp
@@ -8,6 +8,9 @@
 
 #include <map>
 #include <set>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -30,7 +33,34 @@ class Graph<
       ConstructibleGraphTraitList<ConstructibleGraphTraits...>,
       ConstructibleEdgeTraitList<ConstructibleEdgeTraits...> > :
     public GraphTraits... {
-  using Edge = graph::Edge<Node, ConstructibleEdgeTraits...>;
+  using Edge = graph::Edge<Node, EdgeTraits...>;
+  using ContainerEdge = std::conditional_t<
+      contains_type_v<graph::HashTableBased, GraphTraits...>,
+      graph::Edge<Node, graph_impl::HashTableBasedEdge, EdgeTraits...>,
+      graph::Edge<Node, graph_impl::RBTreeBasedEdge, EdgeTraits...> >;
+  using EdgeSet = std::conditional_t<
+      contains_type_v<graph::HashTableBased, GraphTraits...>,
+      std::conditional_t<
+          contains_type_v<graph::Multigraph, GraphTraits...>,
+          std::unordered_multiset<ContainerEdge>,
+          std::unordered_set<ContainerEdge>
+      >,
+      std::conditional_t<
+          contains_type_v<graph::Multigraph, GraphTraits...>,
+          std::multiset<ContainerEdge>,
+          std::set<ContainerEdge>
+      >
+  >;
+  using GraphMap = std::conditional_t<
+      contains_type_v<graph::HashTableBased, GraphTraits...>,
+      std::unordered_map<Node, EdgeSet>,
+      std::map<Node, EdgeSet>
+  >;
+  using NodeSet = std::conditional_t<
+      contains_type_v<graph::HashTableBased, GraphTraits...>,
+      std::unordered_set<Node>,
+      std::set<Node>
+  >;
 
 public:
   Graph() = default;
@@ -38,49 +68,55 @@ public:
         ConstructibleGraphTraits... graph_traits) :
       nodes(std::move(node_list)),
       ConstructibleGraphTraits(std::move(graph_traits))... {
-    if (contains_type<Net<Node>, GraphTraits...>::value) {
+    if (contains_type_v<Net<Node>, GraphTraits...>) {
       nodes.insert(reinterpret_cast<Net<Node>*>(this)->source);
       nodes.insert(reinterpret_cast<Net<Node>*>(this)->sink);
     }
   }
 
   void addEdge(const Edge& edge) {
-    nodes.insert(edge.from);
-    nodes.insert(edge.to);
-    edges[edge.from].insert(edge);
-    edges[edge.to].insert(edge);
-    if (!contains_type<graph::Directed, GraphTraits...>::value) {
-      edges[edge.from].insert(graph::reversed(edge));
-      edges[edge.to].insert(graph::reversed(edge));
+    const ContainerEdge container_edge =
+        reinterpret_cast<const ContainerEdge&>(edge);
+    nodes.insert(container_edge.from);
+    nodes.insert(container_edge.to);
+    edges[container_edge.from].insert(container_edge);
+    edges[container_edge.to].insert(container_edge);
+    if (!contains_type_v<graph::Directed, GraphTraits...>) {
+      edges[container_edge.from].insert(graph::reversed(container_edge));
+      edges[container_edge.to].insert(graph::reversed(container_edge));
     }
   }
 
   std::vector<Edge> inEdges(const Node& node) {
     std::vector<Edge> res;
-    for (const Edge& edge : edges[node])
+    for (const ContainerEdge& edge : edges[node])
       if (edge.to == node)
-        res.push_back(edge);
+        res.push_back(reinterpret_cast<const Edge&>(edge));
     return res;
   }
 
   std::vector<Edge> outEdges(const Node& node) {
-    std::vector<Edge > res;
-    for (const Edge& edge : edges[node])
+    std::vector<Edge> res;
+    for (const ContainerEdge& edge : edges[node])
       if (edge.from == node)
-        res.push_back(edge);
+        res.push_back(reinterpret_cast<const Edge&>(edge));
     return res;
   }
 
   std::vector<Node> neighbors(const Node& node) {
-    std::vector<Node> res;
+    NodeSet res_set;
     for (const Edge& edge : outEdges(node))
-      res.push_back(edge.to);
+      res_set.insert(edge.to);
+    std::vector<Node> res;
+    res.reserve(res_set.size());
+    for (const Node& node : res_set)
+      res.push_back(node);
     return res;
   }
 
 private:
-  std::map<Node, std::set<Edge> > edges;
-  std::set<Node> nodes;
+  GraphMap edges;
+  NodeSet nodes;
 };
 
 }  // graph_impl

--- a/src/impl/graph.hpp
+++ b/src/impl/graph.hpp
@@ -89,6 +89,7 @@ public:
   }
 
   std::vector<Edge> inEdges(const Node& node) {
+    nodes.insert(node);
     std::vector<Edge> res;
     for (const ContainerEdge& edge : edges[node])
       if (edge.to == node)
@@ -97,6 +98,7 @@ public:
   }
 
   std::vector<Edge> outEdges(const Node& node) {
+    nodes.insert(node);
     std::vector<Edge> res;
     for (const ContainerEdge& edge : edges[node])
       if (edge.from == node)
@@ -105,6 +107,7 @@ public:
   }
 
   std::vector<Node> neighbors(const Node& node) {
+    nodes.insert(node);
     NodeSet res_set;
     for (const Edge& edge : outEdges(node))
       res_set.insert(edge.to);

--- a/src/impl/graph_traits.hpp
+++ b/src/impl/graph_traits.hpp
@@ -1,6 +1,10 @@
 #ifndef IMPL_GRAPH_TRAITS_HPP
 #define IMPL_GRAPH_TRAITS_HPP
 
+#include <graph_traits.hpp>
+
+#include <utility>
+
 namespace graph_impl {
 
 template<typename Node>
@@ -9,6 +13,16 @@ public:
   Net(Node source, Node sink) :
       source(std::move(source)), sink(std::move(sink)) {}
   const Node source, sink;
+};
+
+class RBTreeBasedEdge : public graph::EdgeTrait, graph::NoConstructorTrait {
+protected:
+  RBTreeBasedEdge() = default;
+};
+
+class HashTableBasedEdge : public graph::EdgeTrait, graph::NoConstructorTrait {
+protected:
+  HashTableBasedEdge() = default;
 };
 
 }  // graph_impl

--- a/src/impl/graph_traits.hpp
+++ b/src/impl/graph_traits.hpp
@@ -15,16 +15,6 @@ public:
   const Node source, sink;
 };
 
-class RBTreeBasedEdge : public graph::EdgeTrait, graph::NoConstructorTrait {
-protected:
-  RBTreeBasedEdge() = default;
-};
-
-class HashTableBasedEdge : public graph::EdgeTrait, graph::NoConstructorTrait {
-protected:
-  HashTableBasedEdge() = default;
-};
-
 }  // graph_impl
 
 #endif  // IMPL_GRAPH_TRAITS_HPP

--- a/src/impl/meta_utils.hpp
+++ b/src/impl/meta_utils.hpp
@@ -156,6 +156,9 @@ namespace graph_impl {
 template<typename T, typename... Ts>
 using contains_type = contains_type_impl<std::false_type, T, Ts...>::value;
 
+template <typename T, typename... Ts>
+inline constexpr bool contains_type_v = contains_type<T, Ts...>::value;
+
 template<typename Node, typename... Traits>
 using build_graph_traits =
     replace_abstract_traits<

--- a/src/impl/meta_utils.hpp
+++ b/src/impl/meta_utils.hpp
@@ -4,6 +4,7 @@
 #include <graph_traits.hpp>
 #include <impl/graph_traits.hpp>
 
+#include <concepts>
 #include <type_traits>
 
 namespace {
@@ -181,8 +182,34 @@ using constructible_edge_traits =
 
 template<typename T>
 concept Trait =
-    std::is_base_of_v<graph::GraphTrait, T> or
+    std::is_base_of_v<graph::GraphTrait, T> ||
     std::is_base_of_v<graph::EdgeTrait, T>;
+
+template<typename T>
+concept Hashable = requires(T a, T b) {
+  { std::hash<T>{}(a) } -> std::convertible_to<std::size_t>;
+  { a == b } -> std::convertible_to<bool>;
+};
+
+template<typename T>
+concept Comparable =
+    requires(const std::remove_reference_t<T>& a,
+             const std::remove_reference_t<T>& b) {
+  { a < b } -> std::convertible_to<bool>;
+};
+
+template<typename Node, typename... GraphTraits>
+concept HashBaseConsistent =
+    Hashable<Node> && contains_type_v<graph::HashTableBased, GraphTraits...>;
+
+template<typename Node, typename... GraphTraits>
+concept RBTreeBaseConsistent =
+    Comparable<Node> && !contains_type_v<graph::HashTableBased, GraphTraits...>;
+
+template<typename Node, typename... GraphTraits>
+concept BaseConsistent =
+    HashBaseConsistent<Node, GraphTraits...> ||
+    RBTreeBaseConsistent<Node, GraphTraits...>;
 
 }  // graph_impl
 


### PR DESCRIPTION
Finally added `HashTableBased` trait allowing user to choose between rbtree and hash table containers.
Default implementation is red black tree based and forces user to implement ```operator<``` for `Node`s.
In case of `HashTableBased` trait `Graph` uses hash table based containers. In this case user have to satisfy `Hash` requirements for `Node` (e. g. provide `operator==` and specialize `std::hash`).